### PR TITLE
Layouting without connection to reactome

### DIFF
--- a/src/main/java/org/reactome/server/tools/reaction/exporter/InvalidArgumentException.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/InvalidArgumentException.java
@@ -1,0 +1,17 @@
+package org.reactome.server.tools.reaction.exporter;
+
+/**
+ * @author Piotr Gawron
+ *
+ */
+public class InvalidArgumentException extends RuntimeException {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  public InvalidArgumentException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/CompartmentGlyph.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/CompartmentGlyph.java
@@ -29,7 +29,7 @@ public class CompartmentGlyph extends AbstractGlyph implements HasInitial {
 
     private Coordinate labelPosition;
 
-    CompartmentGlyph(Compartment compartment) {
+    public CompartmentGlyph(Compartment compartment) {
         super();
         dbId = compartment.getDbId();
         schemaClass = compartment.getSchemaClass();
@@ -37,7 +37,7 @@ public class CompartmentGlyph extends AbstractGlyph implements HasInitial {
         accession = compartment.getAccession();
     }
 
-    CompartmentGlyph(GoTerm term) {
+    public CompartmentGlyph(GoTerm term) {
         super();
         name = term.getName();
         accession = term.getId().replaceAll("GO:", "");

--- a/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/EntityGlyph.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/EntityGlyph.java
@@ -210,4 +210,8 @@ public class EntityGlyph extends AbstractGlyph {
                 ", dashed=" + isDashed() +
                 '}';
     }
+
+    public void setDashed(Boolean dashed) {
+      this.dashed = dashed;
+    }
 }

--- a/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/Layout.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/Layout.java
@@ -6,6 +6,7 @@ import org.reactome.server.graph.domain.model.ReactionLikeEvent;
 import org.reactome.server.tools.reaction.exporter.layout.common.Bounds;
 import org.reactome.server.tools.reaction.exporter.ontology.GoTerm;
 import org.reactome.server.tools.reaction.exporter.ontology.GoTreeFactory;
+import org.reactome.server.tools.reaction.exporter.ontology.GoTreeFactory.Source;
 
 import java.util.*;
 
@@ -16,6 +17,8 @@ import java.util.*;
  * @author Pascual Lorente (plorente@ebi.ac.uk)
  */
 public class Layout implements HasBounds {
+
+    private Source goTreeSource = Source.REACTOME;
 
     private String pathway;
 
@@ -29,9 +32,21 @@ public class Layout implements HasBounds {
 
     private Map<String, CompartmentGlyph> compartments;
 
+
     public Layout() {
         this.bounds = new Bounds();
         this.compartments = new HashMap<>();
+    }
+
+  /**
+   *
+   * @param source
+   *          defines source of Go tree hierarchy that should be used when layout
+   *          is generated
+   */
+    public Layout(Source source) {
+      this();
+      this.goTreeSource=source;
     }
 
     public void add(EntityGlyph entityGlyph) {
@@ -117,7 +132,7 @@ public class Layout implements HasBounds {
             compartments.add("GO:" + compartment.getAccession());
         }
 
-        GoTerm treeRoot = GoTreeFactory.getTreeWithIntermediateNodes(compartments);
+        GoTerm treeRoot = GoTreeFactory.getTreeWithIntermediateNodes(compartments, goTreeSource);
         compartmentRoot = this.compartments.computeIfAbsent(treeRoot.getAccession(), a -> new CompartmentGlyph(treeRoot));
 
         buildCompartmentHierarchy(compartmentRoot, treeRoot);

--- a/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/Role.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/layout/model/Role.java
@@ -28,4 +28,8 @@ public class Role {
     public String toString() {
         return "(" + n + "x" + type + ")";
     }
+
+    public void setStoichiometry(Integer n) {
+      this.n = n;
+    }
 }

--- a/src/main/java/org/reactome/server/tools/reaction/exporter/ontology/GoTreeFactory.java
+++ b/src/main/java/org/reactome/server/tools/reaction/exporter/ontology/GoTreeFactory.java
@@ -1,13 +1,14 @@
 package org.reactome.server.tools.reaction.exporter.ontology;
 
-import org.reactome.server.tools.reaction.exporter.compartment.ReactomeCompartmentFactory;
+import static org.reactome.server.tools.reaction.exporter.ontology.GoTerm.Directionality.OUTGOING;
+import static org.reactome.server.tools.reaction.exporter.ontology.RelationshipType.surrounded_by;
 
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.reactome.server.tools.reaction.exporter.ontology.GoTerm.Directionality.OUTGOING;
-import static org.reactome.server.tools.reaction.exporter.ontology.RelationshipType.surrounded_by;
+import org.reactome.server.tools.reaction.exporter.InvalidArgumentException;
+import org.reactome.server.tools.reaction.exporter.compartment.ReactomeCompartmentFactory;
 
 /**
  * Helper class to generate compartment trees.
@@ -16,34 +17,11 @@ import static org.reactome.server.tools.reaction.exporter.ontology.RelationshipT
  */
 public class GoTreeFactory {
 
-    private static final Source source = Source.REACTOME;
     private static final String EXTRACELLULAR_REGION_ID = "GO:0005576";
     private static final String CELLULAR_COMPONENT_ID = "GO:0005575";
-    private static Map<String, GoTerm> masterTree;
 
-    static {
-        //noinspection ConstantConditions
-        if (source == Source.GO) {
-            masterTree = GoParser.getGoOntology().values().stream()
-                    .collect(Collectors.toMap(GoTerm::getId, Function.identity()));
-        } else {
-            masterTree = ReactomeCompartmentFactory.getMasterTree();
-        }
-        // NOTE: Reactome diagrams show the cell and any other compartment surrounded by the extracellular region.
-        // This is not represented in Gene Ontology. To bypass this behaviour we create the relationship:
-        //                 (cellular component)-[surrounded_by]->(extracellular_region)
-        final GoTerm cellularComponent = masterTree.get(CELLULAR_COMPONENT_ID);
-        final GoTerm extracellularRegion = masterTree.get(EXTRACELLULAR_REGION_ID);
-        cellularComponent.createRelationship(OUTGOING, surrounded_by, extracellularRegion);
-
-        // To avoid cycles (extracellular region) is not a (cellular component) anymore
-        // (gviteri) IMPORTANT: FOLLOWING LINE DOESN'T WORK FOR RELEASE V71 SINCE ANOTHER PARENT FOR EXTRACELLULAR REGION HAS BEEN ADDED.
-        // extracellularRegion.getParents().remove(cellularComponent);
-
-        // BUG FIX NOTE: As per release V71, extracellularRegion's parent isn't cellular component, so the line above would not work
-        //               and in the later process will lead to stackoverflow exception in the getBranches().
-        extracellularRegion.getParents().clear();
-    }
+    private static Map<String, GoTerm> reactomeSourcedMasterTree = null;
+    private static Map<String, GoTerm> goSourcedMasterTree = null;
 
     private GoTreeFactory() {
     }
@@ -54,8 +32,48 @@ public class GoTreeFactory {
      *
      * @return a copy of the components root, with a smaller copy of the tree containing <em>ids</em>
      */
-    public static GoTerm getTreeWithIntermediateNodes(List<String> goIds) {
-        return getTreeWithIntermediateNodes(GoTreeFactory.masterTree, goIds);
+    public static GoTerm getTreeWithIntermediateNodes(List<String> goIds, Source source) {
+      Map<String, GoTerm> tree;
+      switch (source) {
+        case REACTOME:
+          tree = getLazyLoadedReactomeTree();
+          break;
+        case GO:
+          tree = getLazyLoadedGoTree();
+          break;
+        default:
+          throw new InvalidArgumentException("Don't know how to process tree source: "+source);
+      }
+      return getTreeWithIntermediateNodes(tree, goIds);
+    }
+
+    private static Map<String, GoTerm> getLazyLoadedGoTree() {
+      if (goSourcedMasterTree ==null) {
+        goSourcedMasterTree = GoParser.getGoOntology().values().stream().collect(Collectors.toMap(GoTerm::getId, Function.identity()));
+      }
+      return goSourcedMasterTree ;
+    }
+
+    private static Map<String, GoTerm> getLazyLoadedReactomeTree() {
+      if (reactomeSourcedMasterTree ==null) {
+        reactomeSourcedMasterTree = ReactomeCompartmentFactory.getMasterTree();
+
+        // NOTE: Reactome diagrams show the cell and any other compartment surrounded by the extracellular region.
+        // This is not represented in Gene Ontology. To bypass this behaviour we create the relationship:
+        //                 (cellular component)-[surrounded_by]->(extracellular_region)
+        final GoTerm cellularComponent = reactomeSourcedMasterTree.get(CELLULAR_COMPONENT_ID);
+        final GoTerm extracellularRegion = reactomeSourcedMasterTree.get(EXTRACELLULAR_REGION_ID);
+        cellularComponent.createRelationship(OUTGOING, surrounded_by, extracellularRegion);
+
+        //To avoid cycles (extracellular region) is not a (cellular component) anymore
+        // (gviteri) IMPORTANT: FOLLOWING LINE DOESN'T WORK FOR RELEASE V71 SINCE ANOTHER PARENT FOR EXTRACELLULAR REGION HAS BEEN ADDED.
+        // extracellularRegion.getParents().remove(cellularComponent);
+
+        // BUG FIX NOTE: As per release V71, extracellularRegion's parent isn't cellular component, so the line above would not work
+        //               and in the later process will lead to stackoverflow exception in the getBranches().
+        extracellularRegion.getParents().clear();
+      }
+      return reactomeSourcedMasterTree;
     }
 
     /**
@@ -126,7 +144,7 @@ public class GoTreeFactory {
         return rtn;
     }
 
-    enum Source {
+    public enum Source {
         GO, REACTOME
     }
 }

--- a/src/test/java/org/reactome/server/tools/reaction/exporter/LayoutWithoutDbTest.java
+++ b/src/test/java/org/reactome/server/tools/reaction/exporter/LayoutWithoutDbTest.java
@@ -1,0 +1,137 @@
+package org.reactome.server.tools.reaction.exporter;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.*;
+import java.util.*;
+
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+import org.reactome.server.graph.domain.model.*;
+import org.reactome.server.tools.diagram.data.layout.Diagram;
+import org.reactome.server.tools.diagram.exporter.common.analysis.AnalysisException;
+import org.reactome.server.tools.diagram.exporter.raster.RasterExporter;
+import org.reactome.server.tools.diagram.exporter.raster.api.RasterArgs;
+import org.reactome.server.tools.reaction.exporter.diagram.ReactionDiagramFactory;
+import org.reactome.server.tools.reaction.exporter.layout.algorithm.box.BoxAlgorithm;
+import org.reactome.server.tools.reaction.exporter.layout.model.*;
+import org.reactome.server.tools.reaction.exporter.ontology.GoTreeFactory.Source;
+
+public class LayoutWithoutDbTest {
+
+  Logger logger = LogManager.getLogger(LayoutWithoutDbTest.class);
+
+  private RasterExporter rasterExporter = new RasterExporter();
+
+  long idCounter = 1;
+
+  @Test
+  public void testCreateLayoutWithoutNeo4jDatabase() throws Throwable {
+    try {
+      // create test reaction
+      Compartment childCompartment = createCompartment("0005829", "child-compartment");
+      Compartment parentCompartment = createCompartment("0005886", "parent-compartment");
+
+      ReactionLikeEvent rle = new Reaction();
+
+      SimpleEntity input1 = createEntity("in", parentCompartment);
+
+      SimpleEntity input2 = createEntity("in2", childCompartment);
+
+      rle.setInput(Arrays.asList(input1, input2));
+
+      SimpleEntity modifier = createEntity("cat", childCompartment);
+
+      CatalystActivity catalystActivity = new CatalystActivity();
+      catalystActivity.setPhysicalEntity(modifier);
+      rle.setCatalystActivity(Arrays.asList(catalystActivity));
+      rle.setCompartment(Arrays.asList(childCompartment));
+
+      SimpleEntity output = createEntity("out", parentCompartment);
+      rle.setOutput(Arrays.asList(output));
+
+      // prepare layout object without filling layout information
+      Layout layout = new Layout(Source.GO);
+      List<EntityGlyph> glyphs = new ArrayList<>();
+
+      glyphs.add(createEntityGlyph(input1, "input"));
+      glyphs.add(createEntityGlyph(input2, "input"));
+      glyphs.add(createEntityGlyph(modifier, "catalyst"));
+
+      glyphs.add(createEntityGlyph(output, "output"));
+
+      layout.setParticipants(glyphs);
+      layout.setReactionLikeEvent(rle);
+
+      String stId = "artifitial";
+
+      // compute layout
+      new BoxAlgorithm(layout).compute();
+
+      // check if we can save layout without problems
+      Diagram diagram = ReactionDiagramFactory.get(layout);
+
+      saveImage(stId, stId, diagram, "png");
+      assertTrue(new File(stId + ".png").exists());
+      // Desktop.getDesktop().open(new File(stId + ".png"));
+      new File(stId + ".png").delete();
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+      throw ex;
+    }
+  }
+
+  private EntityGlyph createEntityGlyph(SimpleEntity entity, String type) {
+    EntityGlyph inputGlyph1 = new EntityGlyph();
+    inputGlyph1.setPhysicalEntity(entity);
+    inputGlyph1.setDashed(false);
+
+    inputGlyph1.getRoles().add(createRole(type));
+    return inputGlyph1;
+  }
+
+  private Role createRole(String type) {
+    Role inputRole = new Role();
+    inputRole.setType(type);
+    inputRole.setStoichiometry(1);
+    return inputRole;
+  }
+
+  private SimpleEntity createEntity(String name, Compartment compartment) {
+    long id = idCounter++;
+    SimpleEntity input2 = new SimpleEntity();
+    input2.setDbId(id);
+    input2.setId(id);
+    input2.setStId(id + "");
+    input2.setCompartment(Arrays.asList(compartment));
+    input2.setName(Arrays.asList(name));
+    input2.setInDisease(false);
+    return input2;
+  }
+
+  private Compartment createCompartment(String accession, String name) {
+    long id = idCounter++;
+    Compartment compartment = new Compartment();
+    compartment.setAccession(accession);
+    compartment.setName(name);
+    compartment.setDatabaseName("GO");
+    compartment.setId(id);
+    compartment.setStId(id + "");
+    compartment.setDisplayName(name);
+    return compartment;
+  }
+
+  private void saveImage(String stId, String pStId, Diagram diagram, String format) {
+    try {
+      final File file = new File(String.format("%s.%s", stId, format));
+      OutputStream os = new FileOutputStream(file);
+      RasterArgs args = new RasterArgs(pStId, format).setQuality(8).setMargin(1);
+      rasterExporter.export(diagram, null, args, null, os);
+    } catch (IOException | AnalysisException | TranscoderException e) {
+      e.printStackTrace();
+    }
+  }
+
+}


### PR DESCRIPTION
This pull request allows to use the layout algorithm without a need of reactome ne4j database connection. To do so followings things were modified:
* some methods/constructors were changed from private to public; and some setter were added
* GoTree is lazy loaded - this allows to choose dynamically the source of the GoTree (instead of hardcoded REACTOME database source)
* unit test showing example usage is added 